### PR TITLE
Add `branding` field

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,11 @@
 name: 'Run tests with specified CWL runner'
 author: 'Tomoya Tanjo'
 description: 'Run tests with specified CWL runner'
+
+branding:
+  icon: check
+  color: yellow
+
 inputs:
   test-list:
     description: 'A file that lists test cases in cwltest format'


### PR DESCRIPTION
This action is already available but it is not published in [Github Marketplace](https://github.com/marketplace?type=actions).
This request is a preparation for it by adding [`branding` field](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding) that sets an icon in the Marketplace.
I tentatively choose the [`check`](https://feathericons.com/?query=check) icon with `yellow` color (same as the color of CWL lab icon)

@mr-c Would you make a new release of this action with checking `Publish this release to the GitHub Marketplace` to make it public in the Marketplace?
Only the org admin seems to be able to publish a new action.

Note: I'm not sure that the org admin has to check `Publish this release to the GitHub Marketplace` for each release or it is enough to check it in the first published release...